### PR TITLE
[BUGFIX] Forward amqp options when publish to exchange

### DIFF
--- a/lib/abstract_ascoltatore.js
+++ b/lib/abstract_ascoltatore.js
@@ -128,7 +128,7 @@ AbstractAscoltatore.prototype._setPublish = function() {
     publish = this.publish;
   } else {
     publish = function (topic, payload, options, done) {
-      return f.call(this, topic, payload, done);
+      return f.call(this, topic, payload, options, done);
     };
   }
 

--- a/lib/amqp_ascoltatore.js
+++ b/lib/amqp_ascoltatore.js
@@ -149,12 +149,12 @@ AMQPAscoltatore.prototype.subscribe = function subscribe(topic, callback, done) 
   debug("registered new subscriber for topic " + topic);
 };
 
-AMQPAscoltatore.prototype.publish = function publish(topic, message, done) {
+AMQPAscoltatore.prototype.publish = function publish(topic, message, options, done) {
   this._raiseIfClosed();
 
   debug("new message published to " + topic);
 
-  this._exchange.publish(this._pubTopic(topic), String(message));
+  this._exchange.publish(this._pubTopic(topic), String(message), options);
   defer(done);
 };
 


### PR DESCRIPTION
When publishing a message to rabbitmq via amqp the options object was
dropped in amqp_ascolatore. The options object is now forwarded to
the exchange.