### PR TITLE
[BUGFIX] Forward callback function when publish to exchange

### DIFF
--- a/lib/amqp_ascoltatore.js
+++ b/lib/amqp_ascoltatore.js
@@ -158,8 +158,7 @@ AMQPAscoltatore.prototype.publish = function publish(topic, message, options, do
 
   debug("new message published to " + topic);
 
-  this._exchange.publish(this._pubTopic(topic), String(message), options);
-  defer(done);
+  this._exchange.publish(this._pubTopic(topic), String(message), options, done);
 };
 
 AMQPAscoltatore.prototype.unsubscribe = function unsubscribe(topic, callback, done) {


### PR DESCRIPTION
When publishing a message to rabbitmq via amqp the callback function was
defered independent of the result of exchange publish process.
Now the callback is called by this, enhancing reliability of "done"
state.